### PR TITLE
fix: close button issue on signup page

### DIFF
--- a/front/src/app/signup/page.tsx
+++ b/front/src/app/signup/page.tsx
@@ -398,7 +398,7 @@ const isPasswordValid = Object.values(passwordRules).every(Boolean);
                       {/* Close button */}
                       <motion.button
                         onClick={() => setShowForm(false)}
-                        className="absolute top-4 right-4 p-2 rounded-full bg-slate-800/50 hover:bg-slate-700/50 transition-colors"
+                        className="absolute top-4 right-4 p-2 rounded-full bg-slate-800/50 hover:bg-slate-700/50 transition-colors z-50"
                         whileHover={{ scale: 1.1, rotate: 90 }}
                         whileTap={{ scale: 0.9 }}
                       >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "capstone-proj",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Fixes #37: Signup modal close button was visible but not clickable because it could sit under other layered/animated elements. This change raises the close button’s z-index so clicks reach the handler, allowing the ❌ to reliably close the signup/sign-in modal.